### PR TITLE
Add NAME section so MetaCPAN recognises module

### DIFF
--- a/lib/Graph/Grammar.pm
+++ b/lib/Graph/Grammar.pm
@@ -3,6 +3,10 @@ package Graph::Grammar;
 # ABSTRACT: Grammar for graphs
 # VERSION
 
+=head1 NAME
+
+Graph::Grammar - Graph grammar, i.e. rewriting method
+
 =head1 SYNOPSIS
 
     use Graph::Grammar;


### PR DESCRIPTION
As https://metacpan.org/dist/Graph-Grammar shows, the main module doesn't show as a "module", and the module isn't searchable from the front page of MetaCPAN. This fixes that.